### PR TITLE
Add plant management dialogs

### DIFF
--- a/app.js
+++ b/app.js
@@ -215,6 +215,20 @@ document.addEventListener('DOMContentLoaded', function() {
     const actionPlanFilters = document.getElementById('action-plan-filters');
     const seedsToOrderList = document.getElementById('seeds-to-order-list');
     const bedTimelineControls = document.getElementById('bed-timeline-controls');
+    const addPlantBtn = document.getElementById('add-plant-btn');
+    const plantFormModal = document.getElementById('plantFormModal');
+    const plantForm = document.getElementById('plant-form');
+    const plantNameInput = document.getElementById('plant-name');
+    const plantEmojiInput = document.getElementById('plant-emoji');
+    const plantViabilityInput = document.getElementById('plant-viability');
+    const plantMethodInput = document.getElementById('plant-method');
+    const plantWindowInput = document.getElementById('plant-window');
+    const plantSpacingInput = document.getElementById('plant-spacing');
+    const plantMaturityInput = document.getElementById('plant-maturity');
+    const plantNotesInput = document.getElementById('plant-notes');
+    const plantTypeInput = document.getElementById('plant-type');
+    const plantMonthInput = document.getElementById('plant-month');
+    let editPlantIndex = null;
 
     let currentActionPlanFilter = 'All'; // Default filter for action plan
     let seedsToOrder = [];
@@ -322,6 +336,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     window.openModal = function(plant) {
+        const idx = plantData.indexOf(plant);
         modalBody.innerHTML = `
             <div class="flex items-center gap-4">
                 <div class="text-5xl">${plant.emoji}</div>
@@ -374,12 +389,49 @@ document.addEventListener('DOMContentLoaded', function() {
                 </ul>
             </div>
             ` : ''}
+            <div class="flex gap-2 mt-4">
+                <button class="flex-1 bg-blue-accent text-white px-4 py-2 rounded" onclick="openPlantForm(${idx})">Edit</button>
+                <button class="flex-1 bg-red-500 text-white px-4 py-2 rounded" onclick="deletePlant(${idx})">Delete</button>
+            </div>
         `;
         modal.style.display = 'flex';
     }
 
     window.closeModal = function() {
         modal.style.display = 'none';
+    }
+
+    window.openPlantForm = function(index = null) {
+        editPlantIndex = index;
+        if (index !== null) {
+            const plant = plantData[index];
+            plantNameInput.value = plant.name || '';
+            plantEmojiInput.value = plant.emoji || '';
+            plantViabilityInput.value = plant.viability || '';
+            plantMethodInput.value = plant.method || '';
+            plantWindowInput.value = plant.window || '';
+            plantSpacingInput.value = plant.spacing || '';
+            plantMaturityInput.value = plant.maturity || '';
+            plantNotesInput.value = plant.notes || '';
+            plantTypeInput.value = plant.type || '';
+            plantMonthInput.value = plant.plantingMonth || '';
+        } else {
+            plantForm.reset();
+        }
+        plantFormModal.style.display = 'flex';
+    }
+
+    window.closePlantFormModal = function() {
+        plantFormModal.style.display = 'none';
+    }
+
+    window.deletePlant = function(index) {
+        if (confirm('Delete this plant?')) {
+            plantData.splice(index, 1);
+            renderPlantLibrary();
+            saveData();
+            closeModal();
+        }
     }
 
     function renderBedLayouts(bedType) {
@@ -995,6 +1047,34 @@ document.addEventListener('DOMContentLoaded', function() {
 
     resetFilterBtn.addEventListener('click', () => {
         renderPlantLibrary();
+    });
+
+    addPlantBtn.addEventListener('click', () => {
+        openPlantForm();
+    });
+
+    plantForm.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const newPlant = {
+            name: plantNameInput.value,
+            emoji: plantEmojiInput.value,
+            viability: plantViabilityInput.value,
+            method: plantMethodInput.value,
+            window: plantWindowInput.value,
+            spacing: plantSpacingInput.value,
+            maturity: plantMaturityInput.value,
+            notes: plantNotesInput.value,
+            type: plantTypeInput.value,
+            plantingMonth: parseInt(plantMonthInput.value) || 0
+        };
+        if (editPlantIndex !== null) {
+            plantData[editPlantIndex] = newPlant;
+        } else {
+            plantData.push(newPlant);
+        }
+        renderPlantLibrary();
+        saveData();
+        closePlantFormModal();
     });
 
     renderPlantLibrary();

--- a/index.html
+++ b/index.html
@@ -82,7 +82,8 @@
         <section id="plants" class="mb-12 scroll-mt-24">
             <h2 class="text-3xl font-bold mb-2 text-center">Plant Library</h2>
             <p class="text-center text-gray-600 mb-6">Explore your available seeds. Click any card for detailed planting info. The list is filtered by the timeline above.</p>
-            <div class="flex justify-center mb-4">
+            <div class="flex justify-center mb-4 gap-2">
+                <button id="add-plant-btn" class="bg-green-accent text-white px-4 py-2 rounded-full hover:bg-opacity-80 transition">Add Plant</button>
                 <button id="reset-filter-btn" class="bg-accent text-white px-4 py-2 rounded-full hover:bg-opacity-80 transition">Show All Plants</button>
             </div>
             <div id="plant-library" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4"></div>
@@ -125,6 +126,26 @@
         <div class="modal-content bg-white p-8 rounded-lg shadow-2xl w-11/12 md:w-2/3 lg:w-1/2 max-w-2xl" onclick="event.stopPropagation()">
             <div id="modal-body" class="space-y-4"></div>
             <button onclick="closeModal()" class="mt-6 w-full bg-accent text-white px-4 py-2 rounded-full hover:bg-opacity-80 transition">Close</button>
+        </div>
+    </div>
+    <div id="plantFormModal" class="modal" onclick="closePlantFormModal()">
+        <div class="modal-content bg-white p-8 rounded-lg shadow-2xl w-11/12 md:w-2/3 lg:w-1/2 max-w-2xl" onclick="event.stopPropagation()">
+            <form id="plant-form" class="space-y-4">
+                <input id="plant-name" type="text" class="w-full border p-2 rounded" placeholder="Name" required>
+                <input id="plant-emoji" type="text" class="w-full border p-2 rounded" placeholder="Emoji">
+                <input id="plant-viability" type="text" class="w-full border p-2 rounded" placeholder="Viability">
+                <input id="plant-method" type="text" class="w-full border p-2 rounded" placeholder="Method">
+                <input id="plant-window" type="text" class="w-full border p-2 rounded" placeholder="Planting Window">
+                <input id="plant-spacing" type="number" class="w-full border p-2 rounded" placeholder="Spacing">
+                <input id="plant-maturity" type="text" class="w-full border p-2 rounded" placeholder="Maturity">
+                <input id="plant-notes" type="text" class="w-full border p-2 rounded" placeholder="Notes">
+                <input id="plant-type" type="text" class="w-full border p-2 rounded" placeholder="Type">
+                <input id="plant-month" type="number" class="w-full border p-2 rounded" placeholder="Planting Month">
+                <div class="flex gap-2">
+                    <button type="submit" class="flex-1 bg-green-accent text-white px-4 py-2 rounded">Save</button>
+                    <button type="button" onclick="closePlantFormModal()" class="flex-1 bg-secondary px-4 py-2 rounded">Cancel</button>
+                </div>
+            </form>
         </div>
     </div>
     <script src="app.js"></script>


### PR DESCRIPTION
## Summary
- add "Add Plant" button and plant form modal
- enable edit/delete controls in plant details modal
- save edits via `saveData()`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688671ed02b4832b84664e3d1d869c8f