### PR TITLE
Add customizable bed management

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,6 +76,9 @@
             <h2 class="text-3xl font-bold mb-2 text-center">Interactive Bed Layouts</h2>
             <p class="text-center text-gray-600 mb-6">Visualize your garden. Hover over a square to see what's planted. Use the buttons to switch between bed types.</p>
             <div class="flex justify-center flex-wrap gap-2 mb-6" id="bed-type-selector"></div>
+            <div class="flex justify-center mb-4">
+                <button id="add-bed-btn" class="bg-green-accent text-white px-4 py-2 rounded-full hover:bg-opacity-80 transition">Add Bed</button>
+            </div>
             <div id="bed-layout-container"></div>
         </section>
 
@@ -144,6 +147,19 @@
                 <div class="flex gap-2">
                     <button type="submit" class="flex-1 bg-green-accent text-white px-4 py-2 rounded">Save</button>
                     <button type="button" onclick="closePlantFormModal()" class="flex-1 bg-secondary px-4 py-2 rounded">Cancel</button>
+                </div>
+            </form>
+        </div>
+    </div>
+    <div id="bedFormModal" class="modal" onclick="closeBedFormModal()">
+        <div class="modal-content bg-white p-8 rounded-lg shadow-2xl w-11/12 md:w-1/3 lg:w-1/4 max-w-md" onclick="event.stopPropagation()">
+            <form id="bed-form" class="space-y-4">
+                <input id="bed-name" type="text" class="w-full border p-2 rounded" placeholder="Bed Name" required>
+                <input id="bed-cols" type="number" class="w-full border p-2 rounded" placeholder="Columns" min="1" required>
+                <input id="bed-rows" type="number" class="w-full border p-2 rounded" placeholder="Rows" min="1" required>
+                <div class="flex gap-2">
+                    <button type="submit" class="flex-1 bg-green-accent text-white px-4 py-2 rounded">Save</button>
+                    <button type="button" onclick="closeBedFormModal()" class="flex-1 bg-secondary px-4 py-2 rounded">Cancel</button>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
## Summary
- implement ability to add, edit and delete garden beds
- store bed changes in `localStorage`
- create modal form for bed input
- keep track of which bed type is displayed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688678dbda84832bb305dade486c27ed