### PR TITLE
Add seed list download button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Interactive Fall Garden Plan
 
-This repository contains a single-page web application for planning a fall vegetable garden. The interface includes an interactive planting timeline, garden bed layouts, a plant library, and a step-by-step action plan.
+This repository contains a single-page web application for planning a fall vegetable garden. The interface includes an interactive planting timeline, garden bed layouts, a plant library, and a step-by-step action plan. A button in the "Seeds to Order" section lets you download a text file with any seeds you still need to buy.
 
 ## Opening `index.html`
 

--- a/app.js
+++ b/app.js
@@ -214,6 +214,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const swapSuggestionsContainer = document.getElementById('swap-suggestions-container');
     const actionPlanFilters = document.getElementById('action-plan-filters');
     const seedsToOrderList = document.getElementById('seeds-to-order-list');
+    const downloadSeedsBtn = document.getElementById('download-seeds-btn');
     const bedTimelineControls = document.getElementById('bed-timeline-controls');
     const addPlantBtn = document.getElementById('add-plant-btn');
     const addBedBtn = document.getElementById('add-bed-btn');
@@ -912,6 +913,23 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
+    function downloadSeedsList() {
+        if (seedsToOrder.length === 0) {
+            alert('No seeds to order.');
+            return;
+        }
+        const content = seedsToOrder.join('\n');
+        const blob = new Blob([content], { type: 'text/plain' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'seeds-to-order.txt';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    }
+
     function setupNavbar() {
         const sections = document.querySelectorAll('section');
         const navLinks = document.querySelectorAll('.nav-link');
@@ -1109,6 +1127,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
     addBedBtn.addEventListener('click', () => {
         openBedForm();
+    });
+
+    downloadSeedsBtn.addEventListener('click', () => {
+        downloadSeedsList();
     });
 
     bedForm.addEventListener('submit', (e) => {

--- a/index.html
+++ b/index.html
@@ -121,6 +121,7 @@
             <h2 class="text-3xl font-bold mb-2 text-center">Seeds to Order</h2>
             <p class="text-center text-gray-600 mb-6">This list tracks seeds needed for swapped plants not in your stash.</p>
             <ul id="seeds-to-order-list" class="list-disc list-inside max-w-2xl mx-auto space-y-1"></ul>
+            <button id="download-seeds-btn" class="mt-4 bg-green-accent text-white px-4 py-2 rounded-full hover:bg-opacity-80 transition block mx-auto">Download Seed List</button>
 
         </section>
     </main>


### PR DESCRIPTION
## Summary
- add button in Seeds to Order section to download seed list
- support downloading the seed list as a text file
- document the new download feature in README

## Testing
- `node -c app.js`

------
https://chatgpt.com/codex/tasks/task_e_68867dd33964832ba2fbe503892db16a