### PR TITLE
Add editable location via ZIP

### DIFF
--- a/app.js
+++ b/app.js
@@ -235,6 +235,13 @@ document.addEventListener('DOMContentLoaded', function() {
     const bedNameInput = document.getElementById('bed-name');
     const bedColsInput = document.getElementById('bed-cols');
     const bedRowsInput = document.getElementById('bed-rows');
+
+    const locationDisplay = document.getElementById('location-display');
+    const zoneDisplay = document.getElementById('zone-display');
+    const editLocationBtn = document.getElementById('edit-location-btn');
+    const editLocationForm = document.getElementById('edit-location-form');
+    const zipInput = document.getElementById('zip-input');
+    const saveLocationBtn = document.getElementById('save-location-btn');
     let editPlantIndex = null;
     let editBedType = null;
     let editBedIndex = null;
@@ -244,6 +251,28 @@ document.addEventListener('DOMContentLoaded', function() {
     let seedsToOrder = [];
 
     let actionPlanData = { filter: 'All' };
+
+    const zipData = {
+        "77316": {city: "Montgomery", state: "TX", zone: "9a"},
+        "10001": {city: "New York", state: "NY", zone: "7b"},
+        "90210": {city: "Beverly Hills", state: "CA", zone: "10b"},
+        "33109": {city: "Miami Beach", state: "FL", zone: "11a"},
+        "60601": {city: "Chicago", state: "IL", zone: "6a"},
+        "80202": {city: "Denver", state: "CO", zone: "5b"},
+        "98101": {city: "Seattle", state: "WA", zone: "8b"},
+        "85001": {city: "Phoenix", state: "AZ", zone: "9b"},
+        "55401": {city: "Minneapolis", state: "MN", zone: "4b"},
+        "97201": {city: "Portland", state: "OR", zone: "8b"},
+        "27601": {city: "Raleigh", state: "NC", zone: "7b"},
+        "75201": {city: "Dallas", state: "TX", zone: "8b"},
+        "02108": {city: "Boston", state: "MA", zone: "6b"},
+        "84101": {city: "Salt Lake City", state: "UT", zone: "7a"},
+        "96813": {city: "Honolulu", state: "HI", zone: "11b"},
+        "04101": {city: "Portland", state: "ME", zone: "5b"},
+    };
+
+    const defaultLocation = {zip: "77316", ...zipData["77316"]};
+    let userLocation = {...defaultLocation};
 
     function loadData() {
         const storedPlants = localStorage.getItem('plantLibrary');
@@ -265,6 +294,10 @@ document.addEventListener('DOMContentLoaded', function() {
         if (storedSeeds) {
             seedsToOrder = JSON.parse(storedSeeds);
         }
+        const storedLocation = localStorage.getItem('userLocation');
+        if (storedLocation) {
+            userLocation = JSON.parse(storedLocation);
+        }
     }
 
     function saveData() {
@@ -272,10 +305,18 @@ document.addEventListener('DOMContentLoaded', function() {
         localStorage.setItem('bedLayouts', JSON.stringify(bedLayouts));
         localStorage.setItem('actionPlan', JSON.stringify(actionPlanData));
         localStorage.setItem('seedList', JSON.stringify(seedsToOrder));
+        localStorage.setItem('userLocation', JSON.stringify(userLocation));
+    }
+
+    function updateLocationUI() {
+        locationDisplay.textContent = `${userLocation.city}, ${userLocation.state}`;
+        zoneDisplay.textContent = `USDA Zone ${userLocation.zone}`;
+        zipInput.value = userLocation.zip || '';
     }
 
     loadData();
     currentBedType = Object.keys(bedLayouts)[0] || currentBedType;
+    updateLocationUI();
 
     const viabilityClasses = {
         'Good': 'border-green-accent',
@@ -1131,6 +1172,22 @@ document.addEventListener('DOMContentLoaded', function() {
 
     downloadSeedsBtn.addEventListener('click', () => {
         downloadSeedsList();
+    });
+
+    editLocationBtn.addEventListener('click', () => {
+        editLocationForm.classList.toggle('hidden');
+    });
+
+    saveLocationBtn.addEventListener('click', () => {
+        const zip = zipInput.value.trim();
+        if (zipData[zip]) {
+            userLocation = {zip, ...zipData[zip]};
+            updateLocationUI();
+            editLocationForm.classList.add('hidden');
+            saveData();
+        } else {
+            alert('ZIP code not available.');
+        }
     });
 
     bedForm.addEventListener('submit', (e) => {

--- a/index.html
+++ b/index.html
@@ -42,10 +42,15 @@
         <section id="dashboard" class="mb-12 scroll-mt-24">
             <h2 class="text-3xl font-bold mb-6 text-center">Gardening Dashboard</h2>
             <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-                <div class="bg-white p-6 rounded-lg shadow-lg text-center">
+                <div class="bg-white p-6 rounded-lg shadow-lg text-center" id="location-card">
                     <h3 class="font-semibold text-lg mb-2">Location</h3>
-                    <p class="text-2xl text-accent">Montgomery, TX</p>
-                    <p class="text-gray-500">USDA Zone 9a</p>
+                    <p id="location-display" class="text-2xl text-accent">Montgomery, TX</p>
+                    <p id="zone-display" class="text-gray-500">USDA Zone 9a</p>
+                    <button id="edit-location-btn" class="mt-2 bg-blue-accent text-white px-3 py-1 rounded">Edit</button>
+                    <div id="edit-location-form" class="mt-2 hidden">
+                        <input id="zip-input" type="text" class="border p-1 rounded w-24" placeholder="ZIP">
+                        <button id="save-location-btn" class="bg-green-accent text-white px-2 py-1 rounded ml-1">Save</button>
+                    </div>
                 </div>
                 <div class="bg-white p-6 rounded-lg shadow-lg text-center">
                     <h3 class="font-semibold text-lg mb-2">First Frost</h3>


### PR DESCRIPTION
## Summary
- allow editing location in dashboard
- store user location in localStorage
- update display and zone based on ZIP

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688682111728832ba01a55b4a955bb93