### PR TITLE
Add zone-based task fetch and dynamic What to Do Now

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ This repository contains a single-page web application for planning a fall veget
 1. Ensure you have a modern web browser (Chrome, Firefox, Edge, or Safari).
 2. Clone or download this repository.
 3. Open the `index.html` file directly in your browser. No build process is required.
+The JavaScript is organized into ES modules (`constants.js`, `api.js`, and `app.js`), so keep them together when copying files.
 
-An internet connection is needed because the page loads Tailwind CSS, Chart.js, and fonts from public CDNs.
+An internet connection is needed because the page loads Tailwind CSS, Chart.js, fonts from public CDNs, and now fetches location details and average frost dates from external APIs when you change your ZIP code. If the APIs are unavailable, the app falls back to approximate first and last frost dates based on your USDA zone.
+The "What to Do Now" section also fetches short-term gardening advice from an external API using your USDA zone, so you may need an API key.
 
 ## Prerequisites
 

--- a/api.js
+++ b/api.js
@@ -1,0 +1,76 @@
+import { zoneFrostDates, zoneLastFrostDates } from './constants.js';
+
+export async function lookupFrostDate(lat, lon, season = 1) {
+    try {
+        const stationRes = await fetch(`https://api.farmsense.net/v1/frostdates/stations/?lat=${lat}&lon=${lon}`);
+        if (!stationRes.ok) throw new Error('Station lookup failed');
+        const stations = await stationRes.json();
+        if (!Array.isArray(stations) || stations.length === 0) throw new Error('No station');
+        const station = stations[0].id;
+        const frostRes = await fetch(`https://api.farmsense.net/v1/frostdates/probabilities/?station=${station}&season=${season}`);
+        if (!frostRes.ok) throw new Error('Frost lookup failed');
+        const frostJson = await frostRes.json();
+        const info = frostJson[0];
+        return info && (info.prob_50 || info.prob_70 || info.prob_90 || info.date);
+    } catch (err) {
+        console.error(err);
+        return null;
+    }
+}
+
+export async function lookupZip(zip, zipCache = {}) {
+    try {
+        const zoneRes = await fetch(`https://phzmapi.org/${zip}.json`);
+        if (!zoneRes.ok) throw new Error('Zone lookup failed');
+        const zoneJson = await zoneRes.json();
+
+        const locRes = await fetch(`https://api.zippopotam.us/us/${zip}`);
+        if (!locRes.ok) throw new Error('City lookup failed');
+        const locJson = await locRes.json();
+
+        const place = locJson.places && locJson.places[0];
+        if (!place) throw new Error('No city found');
+
+        let firstFrost = await lookupFrostDate(place.latitude, place.longitude, 1);
+        let lastFrost = await lookupFrostDate(place.latitude, place.longitude, 2);
+        if (!firstFrost && zoneFrostDates[zoneJson.zone]) {
+            firstFrost = zoneFrostDates[zoneJson.zone];
+        }
+        if (!lastFrost && zoneLastFrostDates[zoneJson.zone]) {
+            lastFrost = zoneLastFrostDates[zoneJson.zone];
+        }
+
+        const data = {
+            city: place['place name'],
+            state: place['state abbreviation'],
+            zone: zoneJson.zone,
+            firstFrost,
+            lastFrost,
+            lat: place.latitude,
+            lon: place.longitude
+        };
+        zipCache[zip] = data;
+        return data;
+    } catch (err) {
+        console.error(err);
+        return null;
+    }
+}
+
+export async function fetchTasks(zone, days = 30) {
+    try {
+        const start = new Date();
+        const end = new Date();
+        end.setDate(start.getDate() + days);
+        const startStr = start.toISOString().split('T')[0];
+        const endStr = end.toISOString().split('T')[0];
+        const url = `https://perenual.com/api/gardening-task-planner?hardiness_zone=${zone}&start_date=${startStr}&end_date=${endStr}`;
+        const res = await fetch(url);
+        if (!res.ok) throw new Error('Task lookup failed');
+        const json = await res.json();
+        return json.tasks || [];
+    } catch (err) {
+        console.error(err);
+        return [];
+    }
+}

--- a/app.js
+++ b/app.js
@@ -1,3 +1,5 @@
+import { zoneFrostDates, zoneLastFrostDates, zipData, defaultLocation, zoneTasks } from "./constants.js";
+import { lookupFrostDate, lookupZip, fetchTasks } from "./api.js";
 document.addEventListener('DOMContentLoaded', function() {
     
     let plantData = [
@@ -238,8 +240,15 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const locationDisplay = document.getElementById('location-display');
     const zoneDisplay = document.getElementById('zone-display');
+    const firstFrostDisplay = document.getElementById('first-frost-display');
+    const lastFrostDisplay = document.getElementById('last-frost-display');
+    const todoHeader = document.getElementById('todo-header');
+    const todoWeek = document.getElementById('todo-week');
+    const todoMonth = document.getElementById('todo-month');
+    const totalSpaceDisplay = document.getElementById('total-space-display');
+    const bedCountDisplay = document.getElementById('bed-count-display');
     const editLocationBtn = document.getElementById('edit-location-btn');
-    const editLocationForm = document.getElementById('edit-location-form');
+    const locationFormModal = document.getElementById('locationFormModal');
     const zipInput = document.getElementById('zip-input');
     const saveLocationBtn = document.getElementById('save-location-btn');
     let editPlantIndex = null;
@@ -251,28 +260,8 @@ document.addEventListener('DOMContentLoaded', function() {
     let seedsToOrder = [];
 
     let actionPlanData = { filter: 'All' };
+    let userLocation = { ...defaultLocation };
 
-    const zipData = {
-        "77316": {city: "Montgomery", state: "TX", zone: "9a"},
-        "10001": {city: "New York", state: "NY", zone: "7b"},
-        "90210": {city: "Beverly Hills", state: "CA", zone: "10b"},
-        "33109": {city: "Miami Beach", state: "FL", zone: "11a"},
-        "60601": {city: "Chicago", state: "IL", zone: "6a"},
-        "80202": {city: "Denver", state: "CO", zone: "5b"},
-        "98101": {city: "Seattle", state: "WA", zone: "8b"},
-        "85001": {city: "Phoenix", state: "AZ", zone: "9b"},
-        "55401": {city: "Minneapolis", state: "MN", zone: "4b"},
-        "97201": {city: "Portland", state: "OR", zone: "8b"},
-        "27601": {city: "Raleigh", state: "NC", zone: "7b"},
-        "75201": {city: "Dallas", state: "TX", zone: "8b"},
-        "02108": {city: "Boston", state: "MA", zone: "6b"},
-        "84101": {city: "Salt Lake City", state: "UT", zone: "7a"},
-        "96813": {city: "Honolulu", state: "HI", zone: "11b"},
-        "04101": {city: "Portland", state: "ME", zone: "5b"},
-    };
-
-    const defaultLocation = {zip: "77316", ...zipData["77316"]};
-    let userLocation = {...defaultLocation};
 
     function loadData() {
         const storedPlants = localStorage.getItem('plantLibrary');
@@ -297,6 +286,12 @@ document.addEventListener('DOMContentLoaded', function() {
         const storedLocation = localStorage.getItem('userLocation');
         if (storedLocation) {
             userLocation = JSON.parse(storedLocation);
+            if (!userLocation.firstFrost && window.zoneFrostDates[userLocation.zone]) {
+                userLocation.firstFrost = window.zoneFrostDates[userLocation.zone];
+            }
+            if (!userLocation.lastFrost && window.zoneLastFrostDates[userLocation.zone]) {
+                userLocation.lastFrost = window.zoneLastFrostDates[userLocation.zone];
+            }
         }
     }
 
@@ -311,12 +306,41 @@ document.addEventListener('DOMContentLoaded', function() {
     function updateLocationUI() {
         locationDisplay.textContent = `${userLocation.city}, ${userLocation.state}`;
         zoneDisplay.textContent = `USDA Zone ${userLocation.zone}`;
+        firstFrostDisplay.textContent = userLocation.firstFrost || 'N/A';
+        lastFrostDisplay.textContent = userLocation.lastFrost || 'N/A';
         zipInput.value = userLocation.zip || '';
+    }
+
+    function updateSpaceUI() {
+        let total = 0;
+        let count = 0;
+        Object.entries(bedLayouts).forEach(([type, beds]) => {
+            const [c, r] = type.split('x').map(n => parseInt(n));
+            const area = c * r;
+            count += beds.length;
+            total += area * beds.length;
+        });
+        totalSpaceDisplay.textContent = `${total} sq ft`;
+        bedCountDisplay.textContent = `Across ${count} Raised Bed${count === 1 ? '' : 's'}`;
+    }
+
+    async function updateTodoUI() {
+        const zone = userLocation.zone;
+        const weekTasks = await fetchTasks(zone, 7);
+        const monthTasks = await fetchTasks(zone, 30);
+        const week = weekTasks.length ? weekTasks.join('; ') : (zoneTasks[zone]?.week || zoneTasks.default.week).join('; ');
+        const month = monthTasks.length ? monthTasks.join('; ') : (zoneTasks[zone]?.month || zoneTasks.default.month).join('; ');
+        const today = new Date();
+        todoHeader.textContent = `What to Do Now (as of ${today.toLocaleDateString()})`;
+        todoWeek.textContent = `In the next week: ${week}`;
+        todoMonth.textContent = `Over the next month: ${month}`;
     }
 
     loadData();
     currentBedType = Object.keys(bedLayouts)[0] || currentBedType;
     updateLocationUI();
+    updateSpaceUI();
+    updateTodoUI();
 
     const viabilityClasses = {
         'Good': 'border-green-accent',
@@ -505,6 +529,14 @@ document.addEventListener('DOMContentLoaded', function() {
         bedFormModal.style.display = 'none';
     }
 
+    window.openLocationFormModal = function() {
+        locationFormModal.style.display = 'flex';
+    }
+
+    window.closeLocationFormModal = function() {
+        locationFormModal.style.display = 'none';
+    }
+
     window.deleteBed = function(type, index) {
         if (confirm('Delete this bed?')) {
             bedLayouts[type].splice(index, 1);
@@ -516,6 +548,7 @@ document.addEventListener('DOMContentLoaded', function() {
             }
             setupBedSelectors();
             if (currentBedType) renderBedLayouts(currentBedType);
+            updateSpaceUI();
             saveData();
         }
     }
@@ -580,6 +613,7 @@ document.addEventListener('DOMContentLoaded', function() {
             };
             bedTypeSelector.appendChild(button);
         });
+        updateSpaceUI();
     }
 
     function generatePhaseContent(phase, filterType = 'All') {
@@ -1175,15 +1209,39 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     editLocationBtn.addEventListener('click', () => {
-        editLocationForm.classList.toggle('hidden');
+        locationFormModal.style.display = 'flex';
     });
 
-    saveLocationBtn.addEventListener('click', () => {
+    saveLocationBtn.addEventListener('click', async () => {
         const zip = zipInput.value.trim();
-        if (zipData[zip]) {
-            userLocation = {zip, ...zipData[zip]};
+        let locationInfo = zipData[zip];
+
+        // Always attempt a lookup if we have no cached frost dates
+        if (!locationInfo || !locationInfo.firstFrost || !locationInfo.lastFrost) {
+            const fetched = await lookupZip(zip, zipData);
+            if (fetched) {
+                locationInfo = fetched;
+                zipData[zip] = fetched; // cache for session
+            }
+        }
+
+        if (!locationInfo && zipData[zip]) {
+            // Fallback to cached info without frost date
+            locationInfo = { ...zipData[zip] };
+        }
+
+        if (locationInfo && !locationInfo.firstFrost && window.zoneFrostDates[locationInfo.zone]) {
+            locationInfo.firstFrost = window.zoneFrostDates[locationInfo.zone];
+        }
+        if (locationInfo && !locationInfo.lastFrost && window.zoneLastFrostDates[locationInfo.zone]) {
+            locationInfo.lastFrost = window.zoneLastFrostDates[locationInfo.zone];
+        }
+
+        if (locationInfo) {
+            userLocation = { zip, ...locationInfo };
             updateLocationUI();
-            editLocationForm.classList.add('hidden');
+            updateTodoUI();
+            locationFormModal.style.display = 'none';
             saveData();
         } else {
             alert('ZIP code not available.');
@@ -1215,6 +1273,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         setupBedSelectors();
         renderBedLayouts(currentBedType);
+        updateSpaceUI();
         saveData();
         closeBedFormModal();
     });

--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,97 @@
+export const zoneFrostDates = window.zoneFrostDates || {
+    "3a": "Sep 8 - 15",
+    "3b": "Sep 16 - 23",
+    "4a": "Sep 21 - 30",
+    "4b": "Sep 25 - Oct 5",
+    "5a": "Oct 1 - 10",
+    "5b": "Oct 10 - 20",
+    "6a": "Oct 10 - 20",
+    "6b": "Oct 20 - 30",
+    "7a": "Oct 20 - 30",
+    "7b": "Oct 30 - Nov 10",
+    "8a": "Nov 1 - 10",
+    "8b": "Nov 10 - 20",
+    "9a": "Dec 1 - 10",
+    "9b": "Dec 10 - 20",
+    "10a": "Rare Frost",
+    "10b": "Rare Frost",
+    "11a": "No Frost",
+    "11b": "No Frost"
+};
+window.zoneFrostDates = zoneFrostDates;
+
+export const zoneLastFrostDates = window.zoneLastFrostDates || {
+    "3a": "May 21 - Jun 10",
+    "3b": "May 11 - May 30",
+    "4a": "May 1 - May 20",
+    "4b": "Apr 21 - May 10",
+    "5a": "Apr 11 - Apr 30",
+    "5b": "Apr 1 - Apr 20",
+    "6a": "Mar 20 - Apr 10",
+    "6b": "Mar 10 - Mar 30",
+    "7a": "Mar 1 - Mar 20",
+    "7b": "Feb 20 - Mar 10",
+    "8a": "Feb 10 - Feb 25",
+    "8b": "Feb 1 - Feb 20",
+    "9a": "Jan 15 - Feb 1",
+    "9b": "Jan 1 - Jan 20",
+    "10a": "Rare Frost",
+    "10b": "Rare Frost",
+    "11a": "No Frost",
+    "11b": "No Frost"
+};
+window.zoneLastFrostDates = zoneLastFrostDates;
+
+export const zoneTasks = window.zoneTasks || {
+    default: {
+        week: [
+            'Water deeply if weather is dry',
+            'Keep weeds under control'
+        ],
+        month: [
+            'Add a layer of compost to beds',
+            'Plan upcoming plantings'
+        ]
+    },
+    '9a': {
+        week: [
+            'Direct sow heat-loving crops',
+            'Start fall tomatoes indoors'
+        ],
+        month: [
+            'Prepare soil with compost',
+            'Install trellises for vines'
+        ]
+    }
+};
+window.zoneTasks = zoneTasks;
+
+export const zipData = window.zipData || {
+    "77316": {city: "Montgomery", state: "TX", zone: "9a"},
+    "10001": {city: "New York", state: "NY", zone: "7b"},
+    "90210": {city: "Beverly Hills", state: "CA", zone: "10b"},
+    "33109": {city: "Miami Beach", state: "FL", zone: "11a"},
+    "60601": {city: "Chicago", state: "IL", zone: "6a"},
+    "80202": {city: "Denver", state: "CO", zone: "5b"},
+    "98101": {city: "Seattle", state: "WA", zone: "8b"},
+    "85001": {city: "Phoenix", state: "AZ", zone: "9b"},
+    "55401": {city: "Minneapolis", state: "MN", zone: "4b"},
+    "97201": {city: "Portland", state: "OR", zone: "8b"},
+    "27601": {city: "Raleigh", state: "NC", zone: "7b"},
+    "75201": {city: "Dallas", state: "TX", zone: "8b"},
+    "02108": {city: "Boston", state: "MA", zone: "6b"},
+    "84101": {city: "Salt Lake City", state: "UT", zone: "7a"},
+    "96813": {city: "Honolulu", state: "HI", zone: "11b"},
+    "04101": {city: "Portland", state: "ME", zone: "5b"}
+};
+window.zipData = zipData;
+
+export const defaultLocation = window.defaultLocation || {
+    zip: "77316",
+    city: "Montgomery",
+    state: "TX",
+    zone: "9a",
+    firstFrost: zoneFrostDates["9a"],
+    lastFrost: zoneLastFrostDates["9a"]
+};
+window.defaultLocation = defaultLocation;

--- a/index.html
+++ b/index.html
@@ -41,31 +41,33 @@
         
         <section id="dashboard" class="mb-12 scroll-mt-24">
             <h2 class="text-3xl font-bold mb-6 text-center">Gardening Dashboard</h2>
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-6">
                 <div class="bg-white p-6 rounded-lg shadow-lg text-center" id="location-card">
                     <h3 class="font-semibold text-lg mb-2">Location</h3>
                     <p id="location-display" class="text-2xl text-accent">Montgomery, TX</p>
                     <p id="zone-display" class="text-gray-500">USDA Zone 9a</p>
-                    <button id="edit-location-btn" class="mt-2 bg-blue-accent text-white px-3 py-1 rounded">Edit</button>
-                    <div id="edit-location-form" class="mt-2 hidden">
-                        <input id="zip-input" type="text" class="border p-1 rounded w-24" placeholder="ZIP">
-                        <button id="save-location-btn" class="bg-green-accent text-white px-2 py-1 rounded ml-1">Save</button>
-                    </div>
+                    <button id="edit-location-btn" class="mt-2 bg-blue-accent text-white px-3 py-1 rounded" onclick="openLocationFormModal()">Edit</button>
                 </div>
                 <div class="bg-white p-6 rounded-lg shadow-lg text-center">
                     <h3 class="font-semibold text-lg mb-2">First Frost</h3>
-                    <p class="text-2xl text-blue-accent">Dec 1 - 10</p>
+                    <p id="first-frost-display" class="text-2xl text-blue-accent">Dec 1 - 10</p>
+                    <p class="text-gray-500">Average Date</p>
+                </div>
+                <div class="bg-white p-6 rounded-lg shadow-lg text-center">
+                    <h3 class="font-semibold text-lg mb-2">Last Frost</h3>
+                    <p id="last-frost-display" class="text-2xl text-blue-accent">Feb 1 - Feb 20</p>
                     <p class="text-gray-500">Average Date</p>
                 </div>
                 <div class="bg-white p-6 rounded-lg shadow-lg text-center">
                     <h3 class="font-semibold text-lg mb-2">Total Growing Space</h3>
-                    <p class="text-2xl text-green-accent">60 sq ft</p>
-                    <p class="text-gray-500">Across 7 Raised Beds</p>
+                    <p id="total-space-display" class="text-2xl text-green-accent">60 sq ft</p>
+                    <p id="bed-count-display" class="text-gray-500">Across 7 Raised Beds</p>
                 </div>
             </div>
-            <div class="mt-8 bg-yellow-accent bg-opacity-20 border-l-4 border-yellow-accent text-yellow-accent p-4 rounded-r-lg" role="alert">
-                <p class="font-bold">What to Do Now (Late July - Mid August)</p>
-                <p>Focus on immediate soil preparation for all beds. Direct sow heat-tolerant crops like Zucchini, Cucumbers, and Bush Beans. Start tender Tomato and Pepper seeds indoors as a gamble, or purchase transplants for a better chance of success.</p>
+            <div id="todo-now" class="mt-8 bg-yellow-accent bg-opacity-20 border-l-4 border-yellow-accent text-yellow-accent p-4 rounded-r-lg" role="alert">
+                <p id="todo-header" class="font-bold">What to Do Now</p>
+                <p id="todo-week">Loading weekly tasks…</p>
+                <p id="todo-month" class="mt-2">Loading monthly tasks…</p>
             </div>
         </section>
 
@@ -170,7 +172,18 @@
             </form>
         </div>
     </div>
-    <script src="app.js"></script>
+    <div id="locationFormModal" class="modal" onclick="closeLocationFormModal()">
+        <div class="modal-content bg-white p-8 rounded-lg shadow-2xl w-11/12 md:w-1/3 max-w-md" onclick="event.stopPropagation()">
+            <div class="space-y-4">
+                <input id="zip-input" type="text" class="w-full border p-2 rounded" placeholder="ZIP Code">
+                <div class="flex gap-2">
+                    <button id="save-location-btn" class="flex-1 bg-green-accent text-white px-4 py-2 rounded">Save</button>
+                    <button type="button" onclick="closeLocationFormModal()" class="flex-1 bg-secondary px-4 py-2 rounded">Cancel</button>
+                </div>
+            </div>
+        </div>
+    </div>
+    <script type="module" src="app.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show dynamic "What to Do Now" tasks
- store fallback advice in `zoneTasks`
- fetch tasks from a public API when available
- update README about the new API call

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688683ce1754832b9167cd1afb254b39