### PR TITLE
Fix parseWindow for undefined values

### DIFF
--- a/app.js
+++ b/app.js
@@ -795,7 +795,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }
 
         function parseWindow(str) {
-            if (!str) return [null, null];
+            if (typeof str !== 'string' || !str) return [null, null];
 
             const matches = str.toLowerCase().match(/(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)/g);
             if (!matches) return [null, null];


### PR DESCRIPTION
## Summary
- guard against non-string values in `parseWindow`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68878d223ab4832bb2353c025191e753