### PR TITLE
Fix frost date API protocol

### DIFF
--- a/api.js
+++ b/api.js
@@ -2,12 +2,12 @@ import { zoneFrostDates, zoneLastFrostDates } from './constants.js';
 
 export async function lookupFrostDate(lat, lon, season = 1) {
     try {
-        const stationRes = await fetch(`https://api.farmsense.net/v1/frostdates/stations/?lat=${lat}&lon=${lon}`);
+        const stationRes = await fetch(`http://api.farmsense.net/v1/frostdates/stations/?lat=${lat}&lon=${lon}`);
         if (!stationRes.ok) throw new Error('Station lookup failed');
         const stations = await stationRes.json();
         if (!Array.isArray(stations) || stations.length === 0) throw new Error('No station');
         const station = stations[0].id;
-        const frostRes = await fetch(`https://api.farmsense.net/v1/frostdates/probabilities/?station=${station}&season=${season}`);
+        const frostRes = await fetch(`http://api.farmsense.net/v1/frostdates/probabilities/?station=${station}&season=${season}`);
         if (!frostRes.ok) throw new Error('Frost lookup failed');
         const frostJson = await frostRes.json();
         const info = frostJson[0];


### PR DESCRIPTION
## Summary
- fix lookupFrostDate to use HTTP instead of HTTPS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6887ead8508c832bb48a029a04ebcc38