### PR TITLE
Remove frost date fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains a single-page web application for planning a fall veget
 3. Open the `index.html` file directly in your browser. No build process is required.
 The JavaScript is organized into ES modules (`constants.js`, `tasks.js`, `api.js`, and `app.js`), so keep them together when copying files.
 
-An internet connection is needed because the page loads Tailwind CSS, Chart.js, fonts from public CDNs, and now fetches location details and average frost dates from external APIs when you change your ZIP code. If the APIs are unavailable, the app falls back to approximate first and last frost dates based on your USDA zone.
+An internet connection is needed because the page loads Tailwind CSS, Chart.js, fonts from public CDNs, and now fetches location details and average frost dates from external APIs when you change your ZIP code. If the APIs are unavailable, frost dates will simply be unavailable until the lookup succeeds.
 The "What to Do Now" section uses a built-in dataset of weekly and monthly tasks for each USDA zone, so no external API key is required.
 The planting timeline automatically starts with the current month and highlights each crop's planting and harvest windows based on your zone. When a plant doesn't have a predefined window in `constants.js`, the page now queries the OpenFarm API to fetch one on demand.
 

--- a/api.js
+++ b/api.js
@@ -1,4 +1,4 @@
-import { zoneFrostDates, zoneLastFrostDates } from './constants.js';
+// Frost dates will be provided solely by the API; zone-based fallbacks removed.
 
 const FARMSENSE_PROXY =
     'https://thingproxy.freeboard.io/fetch/https://api.farmsense.net/v1/frostdates';
@@ -41,14 +41,8 @@ export async function lookupZip(zip, zipCache = {}) {
         const place = locJson.places && locJson.places[0];
         if (!place) throw new Error('No city found');
 
-        let firstFrost = await lookupFrostDate(place.latitude, place.longitude, 1);
-        let lastFrost = await lookupFrostDate(place.latitude, place.longitude, 2);
-        if (!firstFrost && zoneFrostDates[zoneJson.zone]) {
-            firstFrost = zoneFrostDates[zoneJson.zone];
-        }
-        if (!lastFrost && zoneLastFrostDates[zoneJson.zone]) {
-            lastFrost = zoneLastFrostDates[zoneJson.zone];
-        }
+        const firstFrost = await lookupFrostDate(place.latitude, place.longitude, 1);
+        const lastFrost = await lookupFrostDate(place.latitude, place.longitude, 2);
 
         const data = {
             city: place['place name'],

--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-import { zoneFrostDates, zoneLastFrostDates, zipData, defaultLocation, plantingWindows } from "./constants.js";
+import { zipData, defaultLocation, plantingWindows } from "./constants.js";
 import { zoneTasks } from "./tasks.js";
 import { lookupFrostDate, lookupZip, fetchOpenFarmWindow } from "./api.js";
 document.addEventListener('DOMContentLoaded', async function() {
@@ -319,12 +319,6 @@ document.addEventListener('DOMContentLoaded', async function() {
         const storedLocation = localStorage.getItem('userLocation');
         if (storedLocation) {
             userLocation = JSON.parse(storedLocation);
-            if (!userLocation.firstFrost && window.zoneFrostDates[userLocation.zone]) {
-                userLocation.firstFrost = window.zoneFrostDates[userLocation.zone];
-            }
-            if (!userLocation.lastFrost && window.zoneLastFrostDates[userLocation.zone]) {
-                userLocation.lastFrost = window.zoneLastFrostDates[userLocation.zone];
-            }
         }
         const storedWindows = localStorage.getItem('plantingWindowsCache');
         if (storedWindows) {
@@ -1341,12 +1335,7 @@ if (fetched) {
             locationInfo = { ...zipData[zip] };
         }
 
-        if (locationInfo && !locationInfo.firstFrost && window.zoneFrostDates[locationInfo.zone]) {
-            locationInfo.firstFrost = window.zoneFrostDates[locationInfo.zone];
-        }
-        if (locationInfo && !locationInfo.lastFrost && window.zoneLastFrostDates[locationInfo.zone]) {
-            locationInfo.lastFrost = window.zoneLastFrostDates[locationInfo.zone];
-        }
+
 
         if (locationInfo) {
             userLocation = { zip, ...locationInfo };

--- a/constants.js
+++ b/constants.js
@@ -1,46 +1,6 @@
-export const zoneFrostDates = window.zoneFrostDates || {
-    "3a": "Sep 8 - 15",
-    "3b": "Sep 16 - 23",
-    "4a": "Sep 21 - 30",
-    "4b": "Sep 25 - Oct 5",
-    "5a": "Oct 1 - 10",
-    "5b": "Oct 10 - 20",
-    "6a": "Oct 10 - 20",
-    "6b": "Oct 20 - 30",
-    "7a": "Oct 20 - 30",
-    "7b": "Oct 30 - Nov 10",
-    "8a": "Nov 1 - 10",
-    "8b": "Nov 10 - 20",
-    "9a": "Dec 1 - 10",
-    "9b": "Dec 10 - 20",
-    "10a": "Rare Frost",
-    "10b": "Rare Frost",
-    "11a": "No Frost",
-    "11b": "No Frost"
-};
-window.zoneFrostDates = zoneFrostDates;
-
-export const zoneLastFrostDates = window.zoneLastFrostDates || {
-    "3a": "May 21 - Jun 10",
-    "3b": "May 11 - May 30",
-    "4a": "May 1 - May 20",
-    "4b": "Apr 21 - May 10",
-    "5a": "Apr 11 - Apr 30",
-    "5b": "Apr 1 - Apr 20",
-    "6a": "Mar 20 - Apr 10",
-    "6b": "Mar 10 - Mar 30",
-    "7a": "Mar 1 - Mar 20",
-    "7b": "Feb 20 - Mar 10",
-    "8a": "Feb 10 - Feb 25",
-    "8b": "Feb 1 - Feb 20",
-    "9a": "Jan 15 - Feb 1",
-    "9b": "Jan 1 - Jan 20",
-    "10a": "Rare Frost",
-    "10b": "Rare Frost",
-    "11a": "No Frost",
-    "11b": "No Frost"
-};
-window.zoneLastFrostDates = zoneLastFrostDates;
+// Historical frost date estimates were previously stored in zoneFrostDates and
+// zoneLastFrostDates. These fallbacks have been removed so the app relies
+// entirely on live data from the frost date API.
 
 
 export const zipData = window.zipData || {
@@ -68,8 +28,9 @@ export const defaultLocation = window.defaultLocation || {
     city: "Montgomery",
     state: "TX",
     zone: "9a",
-    firstFrost: zoneFrostDates["9a"],
-    lastFrost: zoneLastFrostDates["9a"]
+    // Frost dates will be fetched from the API on load
+    firstFrost: null,
+    lastFrost: null
 };
 window.defaultLocation = defaultLocation;
 

--- a/index.html
+++ b/index.html
@@ -50,12 +50,12 @@
                 </div>
                 <div class="bg-white p-6 rounded-lg shadow-lg text-center">
                     <h3 class="font-semibold text-lg mb-2">First Frost</h3>
-                    <p id="first-frost-display" class="text-2xl text-blue-accent">Dec 1 - 10</p>
+                    <p id="first-frost-display" class="text-2xl text-blue-accent">N/A</p>
                     <p class="text-gray-500">Average Date</p>
                 </div>
                 <div class="bg-white p-6 rounded-lg shadow-lg text-center">
                     <h3 class="font-semibold text-lg mb-2">Last Frost</h3>
-                    <p id="last-frost-display" class="text-2xl text-blue-accent">Feb 1 - Feb 20</p>
+                    <p id="last-frost-display" class="text-2xl text-blue-accent">N/A</p>
                     <p class="text-gray-500">Average Date</p>
                 </div>
                 <div class="bg-white p-6 rounded-lg shadow-lg text-center">


### PR DESCRIPTION
## Summary
- rely only on the API for frost dates
- drop fallback data and imports
- update default location and placeholders
- document new behavior in README

## Testing
- `node -c api.js`
- `node -c app.js`
- `node -c constants.js`
- `node -c tasks.js`


------
https://chatgpt.com/codex/tasks/task_e_6888310d2fe8832ba3a07f7aeec23830